### PR TITLE
chore: update integration test params

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
+          make integration-test API_GATEWAY_VDP_HOST=localhost API_GATEWAY_VDP_PORT=8080
 
       - name: Checkout (pipeline)
         uses: actions/checkout@v3
@@ -127,7 +127,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
+          make integration-test API_GATEWAY_VDP_HOST=localhost API_GATEWAY_VDP_PORT=8080
 
       - name: Checkout (connector)
         uses: actions/checkout@v3
@@ -141,32 +141,4 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
-
-      - name: Checkout (model)
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/model-backend
-
-      - name: Load .env file
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Run integration-test
-        run: |
-          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
-
-      - name: Checkout (mgmt)
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/mgmt-backend
-
-      - name: Load .env file
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Run integration-test
-        run: |
-          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
+          make integration-test API_GATEWAY_VDP_HOST=localhost API_GATEWAY_VDP_PORT=8080

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ unit-test:       				## Run unit test
 .PHONY: integration-test
 integration-test:				## Run integration test
 	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
-		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_VDP_HOST=${API_GATEWAY_VDP_HOST} -e API_GATEWAY_VDP_PORT=${API_GATEWAY_VDP_PORT} \
 		integration-test/grpc.js --no-usage-report --quiet
 
 .PHONY: help

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -1,14 +1,14 @@
 import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
 
 let proto
-let pHost, cHost, mgHost, ctHost
-let pPublicPort, pPrivatePort, cPublicPort, cPrivatePort, mgPublicPort, mgPrivatePort, ctPrivatePort
+let pHost, cHost, ctHost
+let pPublicPort, pPrivatePort, cPublicPort, cPrivatePort, mgPrivatePort, ctPrivatePort
 
-if (__ENV.API_GATEWAY_HOST && !__ENV.API_GATEWAY_PORT || !__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT) {
-  fail("both API_GATEWAY_HOST and API_GATEWAY_PORT should be properly configured.")
+if (__ENV.API_GATEWAY_VDP_HOST && !__ENV.API_GATEWAY_VDP_PORT || !__ENV.API_GATEWAY_VDP_HOST && __ENV.API_GATEWAY_VDP_PORT) {
+  fail("both API_GATEWAY_VDP_HOST and API_GATEWAY_VDP_PORT should be properly configured.")
 }
 
-export const apiGatewayMode = (__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT);
+export const apiGatewayMode = (__ENV.API_GATEWAY_VDP_HOST && __ENV.API_GATEWAY_VDP_PORT);
 
 if (__ENV.API_GATEWAY_PROTOCOL) {
   if (__ENV.API_GATEWAY_PROTOCOL !== "http" && __ENV.API_GATEWAY_PROTOCOL != "https") {
@@ -21,15 +21,13 @@ if (__ENV.API_GATEWAY_PROTOCOL) {
 
 if (apiGatewayMode) {
   // api-gateway mode
-  pHost = cHost = mgHost = ctHost = __ENV.API_GATEWAY_HOST
+  pHost = cHost = ctHost = __ENV.API_GATEWAY_VDP_HOST
   pPrivatePort = 3081
   cPrivatePort = 3082
-  mgPrivatePort = 3084
   ctPrivatePort = 3085
-  pPublicPort = cPublicPort = mgPublicPort = 8080
+  pPublicPort = cPublicPort = 8080
 } else {
   // direct microservice mode  
-  mgHost = "mgmt-backend"
   pHost = "pipeline-backend"
   cHost = "connector-backend"
   ctHost = "controller-vdp"
@@ -39,15 +37,12 @@ if (apiGatewayMode) {
   ctPrivatePort = 3085
   pPublicPort = 8081
   cPublicPort = 8082
-  mgPublicPort = 8084
 }
 
 export const connectorPublicHost = `${proto}://${cHost}:${cPublicPort}`;
 export const connectorPrivateHost = `${proto}://${cHost}:${cPrivatePort}`;
 export const pipelinePublicHost = `${proto}://${pHost}:${pPublicPort}`;
 export const pipelinePrivateHost = `${proto}://${pHost}:${pPrivatePort}`;
-export const mgmtPublicHost = `${proto}://${mgHost}:${mgPublicPort}`;
-export const mgmtPrivateHost = `${proto}://${mgHost}:${mgPrivatePort}`;
 export const controllerPrivateHost = `${proto}://${ctHost}:${ctPrivatePort}`;
 
 export const controllerGRPCPrivateHost = `${ctHost}:${ctPrivatePort}`;


### PR DESCRIPTION
Because

- Some of our test-cases may be cross projects, we need to use different apigateway endpoints

This commit

- update integration test params
