### PR TITLE
chore: periodically check all connectors except for Airbyte

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230627140850-cfd958552c23
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230713190717-db342a853567
 	github.com/knadh/koanf v1.5.0
 	github.com/redis/go-redis/v9 v9.0.2
 	github.com/stretchr/testify v1.8.3

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,8 @@ github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEF
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230627140850-cfd958552c23 h1:KiCIryxQb22byMZj9fQCiAO5L1M+N/LU6BaL121Toy4=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230627140850-cfd958552c23/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230713190717-db342a853567 h1:e4X/bumXkCgCoZKYN2t+2agP8KfDbW3sps8wQrE+OJQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230713190717-db342a853567/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
@@ -348,6 +350,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -29,7 +29,7 @@ type Service interface {
 	UpdateResourceWorkflowId(ctx context.Context, resourcePermalink string, workflowID string) error
 	DeleteResourceWorkflowId(ctx context.Context, resourcePermalink string) error
 	ProbeBackend(ctx context.Context, cancel context.CancelFunc) error
-	ProbeConnectors(ctx context.Context, cancel context.CancelFunc) error
+	ProbeConnectors(ctx context.Context, cancel context.CancelFunc, firstProbe bool) error
 	ProbePipelines(ctx context.Context, cancel context.CancelFunc) error
 }
 


### PR DESCRIPTION
Because

- we should check the connector state periodically

This commit

- periodically check all connectors except for Airbyte connector
