### PR TITLE
chore: fix ProbeConnector pagination bug

### DIFF
--- a/pkg/service/connector.go
+++ b/pkg/service/connector.go
@@ -16,7 +16,9 @@ func (s *service) ProbeConnectors(ctx context.Context, cancel context.CancelFunc
 
 	logger, _ := logger.GetZapLogger(ctx)
 
-	defResp, err := s.connectorPublicClient.ListConnectorDefinitions(ctx, &connectorPB.ListConnectorDefinitionsRequest{})
+	// the number of connector definitions is controllable, using fix size here should be enough
+	pageSize := int64(1000)
+	defResp, err := s.connectorPublicClient.ListConnectorDefinitions(ctx, &connectorPB.ListConnectorDefinitionsRequest{PageSize: &pageSize})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Because

- the `ListConnectorDefinitions()` in `ProbeConnector()` didn't use correct pagination

This commit

- fix pagination bug
