### PR TITLE
chore: adopt new `connector-resources` endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230713190717-db342a853567
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa
 	github.com/knadh/koanf v1.5.0
 	github.com/redis/go-redis/v9 v9.0.2
 	github.com/stretchr/testify v1.8.3

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,6 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230627140850-cfd958552c23 h1:KiCIryxQb22byMZj9fQCiAO5L1M+N/LU6BaL121Toy4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230627140850-cfd958552c23/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230713190717-db342a853567 h1:e4X/bumXkCgCoZKYN2t+2agP8KfDbW3sps8wQrE+OJQ=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230713190717-db342a853567/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
@@ -350,7 +348,6 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230713190717-db342a853567 h1:e4X/bumXkCgCoZKYN2t+2agP8KfDbW3sps8wQrE+OJQ=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230713190717-db342a853567/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa h1:QFj7GA+tLaxMCCIJfLMif2y0nPGDCU1+AJF08ORiRhQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/pkg/service/connector.go
+++ b/pkg/service/connector.go
@@ -28,18 +28,18 @@ func (s *service) ProbeConnectors(ctx context.Context, cancel context.CancelFunc
 		}
 	}
 
-	resp, err := s.connectorPrivateClient.ListConnectorsAdmin(ctx, &connectorPB.ListConnectorsAdminRequest{})
+	resp, err := s.connectorPrivateClient.ListConnectorResourcesAdmin(ctx, &connectorPB.ListConnectorResourcesAdminRequest{})
 
 	if err != nil {
 		return err
 	}
 
-	connectors := resp.Connectors
+	connectors := resp.ConnectorResources
 	nextPageToken := &resp.NextPageToken
 	totalSize := resp.TotalSize
 
 	for totalSize > util.DefaultPageSize {
-		resp, err := s.connectorPrivateClient.ListConnectorsAdmin(ctx, &connectorPB.ListConnectorsAdminRequest{
+		resp, err := s.connectorPrivateClient.ListConnectorResourcesAdmin(ctx, &connectorPB.ListConnectorResourcesAdminRequest{
 			PageToken: nextPageToken,
 		})
 
@@ -49,10 +49,10 @@ func (s *service) ProbeConnectors(ctx context.Context, cancel context.CancelFunc
 
 		nextPageToken = &resp.NextPageToken
 		totalSize -= util.DefaultPageSize
-		connectors = append(connectors, resp.Connectors...)
+		connectors = append(connectors, resp.ConnectorResources...)
 	}
 
-	filConnectors := []*connectorPB.Connector{}
+	filConnectors := []*connectorPB.ConnectorResource{}
 	for idx := range connectors {
 		if _, isAirbyte := airbyteDefNames[connectors[idx].ConnectorDefinitionName]; firstProbe || !isAirbyte {
 			filConnectors = append(filConnectors, connectors[idx])
@@ -66,11 +66,11 @@ func (s *service) ProbeConnectors(ctx context.Context, cancel context.CancelFunc
 		resourcePermalink := util.ConvertUIDToResourcePermalink(connector.Uid, connectorType)
 
 		// if user desires disconnected
-		if connector.State == connectorPB.Connector_STATE_DISCONNECTED {
+		if connector.State == connectorPB.ConnectorResource_STATE_DISCONNECTED {
 			if err := s.UpdateResourceState(ctx, &controllerPB.Resource{
 				ResourcePermalink: resourcePermalink,
 				State: &controllerPB.Resource_ConnectorState{
-					ConnectorState: connectorPB.Connector_STATE_DISCONNECTED,
+					ConnectorState: connectorPB.ConnectorResource_STATE_DISCONNECTED,
 				},
 			}); err != nil {
 				logger.Error(err.Error())
@@ -78,11 +78,11 @@ func (s *service) ProbeConnectors(ctx context.Context, cancel context.CancelFunc
 			continue
 		}
 		// if user desires connected
-		resp, err := s.connectorPrivateClient.CheckConnector(ctx, &connectorPB.CheckConnectorRequest{
-			ConnectorPermalink: fmt.Sprintf("%s/%s", connectorType, connector.Uid),
+		resp, err := s.connectorPrivateClient.CheckConnectorResource(ctx, &connectorPB.CheckConnectorResourceRequest{
+			Permalink: fmt.Sprintf("%s/%s", connectorType, connector.Uid),
 		})
 
-		state := connectorPB.Connector_STATE_UNSPECIFIED
+		state := connectorPB.ConnectorResource_STATE_UNSPECIFIED
 		if err != nil {
 			logger.Error(err.Error())
 		} else {

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -105,15 +105,15 @@ func (s *service) ProbePipelines(ctx context.Context, cancel context.CancelFunc)
 				switch v := r.State.(type) {
 				case *controllerPB.Resource_ConnectorState:
 					switch v.ConnectorState {
-					case connectorPB.Connector_STATE_DISCONNECTED:
+					case connectorPB.ConnectorResource_STATE_DISCONNECTED:
 						pipelineResource.State = &controllerPB.Resource_PipelineState{
 							PipelineState: pipelinePB.Pipeline_STATE_INACTIVE,
 						}
-					case connectorPB.Connector_STATE_UNSPECIFIED:
+					case connectorPB.ConnectorResource_STATE_UNSPECIFIED:
 						pipelineResource.State = &controllerPB.Resource_PipelineState{
 							PipelineState: pipelinePB.Pipeline_STATE_UNSPECIFIED,
 						}
-					case connectorPB.Connector_STATE_ERROR:
+					case connectorPB.ConnectorResource_STATE_ERROR:
 						pipelineResource.State = &controllerPB.Resource_PipelineState{
 							PipelineState: pipelinePB.Pipeline_STATE_ERROR,
 						}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -90,7 +90,7 @@ func (s *service) GetResourceState(ctx context.Context, resourcePermalink string
 		return &controllerPB.Resource{
 			ResourcePermalink: resourcePermalink,
 			State: &controllerPB.Resource_ConnectorState{
-				ConnectorState: connectorPB.Connector_State(stateEnumValue),
+				ConnectorState: connectorPB.ConnectorResource_State(stateEnumValue),
 			},
 			Progress: nil,
 		}, nil

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -103,7 +103,7 @@ func TestGetResourceState(t *testing.T) {
 
 		resource, err := s.GetResourceState(ctx, connectorResourceName)
 
-		assert.Equal(t, connectorPB.Connector_STATE_UNSPECIFIED, resource.GetConnectorState())
+		assert.Equal(t, connectorPB.ConnectorResource_STATE_UNSPECIFIED, resource.GetConnectorState())
 
 		assert.NoError(t, err)
 	})
@@ -208,7 +208,7 @@ func TestUpdateResourceState(t *testing.T) {
 		resource := controllerPB.Resource{
 			ResourcePermalink: connectorResourceName,
 			State: &controllerPB.Resource_ConnectorState{
-				ConnectorState: connectorPB.Connector_STATE_UNSPECIFIED,
+				ConnectorState: connectorPB.ConnectorResource_STATE_UNSPECIFIED,
 			},
 		}
 


### PR DESCRIPTION
Because

- In proto, `Connector` has been renamed to `ConnectorResource`

This commit

- adopt `connector-resources/` endpoints
