### PR TITLE
docs(contributing): update guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,9 +14,62 @@ Please refer to the [community contributing section](https://github.com/instill-
 
 Before delving into the details to come up with your first PR, please familiarise yourself with the project structure of [Instill Core](https://github.com/instill-ai/community#instill-core).
 
-### Prerequisites & Development
+### Prerequisites
 
-Please refer to [here](../README.md).
+- [Instill VDP](https://github.com/instill-ai/vdp)
+
+### Local development
+
+On the local machine, clone `vdp` repository in your workspace, move to the repository folder, and launch all dependent microservices:
+
+```bash
+$ cd <your-workspace>
+$ git clone https://github.com/instill-ai/vdp.git
+$ cd vdp
+$ make dev PROFILE=controller
+```
+
+Clone `controller-vdp` repository in your workspace and move to the repository folder:
+
+```bash
+$ cd <your-workspace>
+$ git clone https://github.com/instill-ai/controller-vdp.git
+$ cd controller-vdp
+```
+
+### Build the dev image
+
+```bash
+$ make build
+```
+
+### Run the dev container
+
+```bash
+$ make dev
+```
+
+Now, you have the Go project set up in the container, in which you can compile and run the binaries together with the integration test in each container shell.
+
+### Run the server
+
+```bash
+$ docker exec -it controller-vdp /bin/bash
+$ go run ./cmd/main
+```
+
+### Run the integration test
+
+```bash
+$ docker exec -it controller-vdp /bin/bash
+$ make integration-test
+```
+
+### Stop the dev container
+
+```bash
+$ make stop
+```
 
 ### Sending PRs
 

--- a/README.md
+++ b/README.md
@@ -4,66 +4,17 @@
 
 `controller-vdp` service monitors the state of other services and resources within Instill VDP.
 
-## Local dev
-
-On the local machine, clone `vdp` repository in your workspace, move to the repository folder, and launch all dependent microservices:
-
-```bash
-$ cd <your-workspace>
-$ git clone https://github.com/instill-ai/vdp.git
-$ cd vdp
-$ make dev PROFILE=controller
-```
-
-Clone `controller-vdp` repository in your workspace and move to the repository folder:
-
-```bash
-$ cd <your-workspace>
-$ git clone https://github.com/instill-ai/controller-vdp.git
-$ cd controller-vdp
-```
-
-### Build the dev image
-
-```bash
-$ make build
-```
-
-### Run the dev container
-
-```bash
-$ make dev
-```
-
-Now, you have the Go project set up in the container, in which you can compile and run the binaries together with the integration test in each container shell.
-
-### Run the server
-
-```bash
-$ docker exec -it controller-vdp /bin/bash
-$ go run ./cmd/main
-```
-
-### Run the integration test
-
-```bash
-$ docker exec -it controller-vdp /bin/bash
-$ make integration-test
-```
-
-### Stop the dev container
-
-```bash
-$ make stop
-```
-
-### CI/CD
+## CI/CD
 
 The latest images will be published to Docker Hub [repository](https://hub.docker.com/r/instill/controller) at release.
 
 ## Contributing
 
 Please refer to the [Contributing Guidelines](./.github/CONTRIBUTING.md) for more details.
+
+## Community
+
+Please refer to the [community](https://github.com/instill-ai/community) repository.
 
 ## License
 


### PR DESCRIPTION
Because

- we'd like to keep `README.md` succinct and put contributing guidelines
in the repo `.github/CONTRIBUTING.md`

This commit

- move the content of local development into the repo contributing
guideline