### PR TITLE
refactor(logging): reduce unnecessary log emission

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -112,11 +112,7 @@ func main() {
 		grpc_zap.WithDecider(func(fullMethodName string, err error) bool {
 			// will not log gRPC calls if it was a call to liveness or readiness and no error was raised
 			if err == nil {
-				if match, _ := regexp.MatchString("vdp.model.v1alpha.ModelPublicService/.*ness$", fullMethodName); match {
-					return false
-				}
-				// stop logging successful private function calls
-				if match, _ := regexp.MatchString("model.model.v1alpha.ModelPrivateService/.*Admin$", fullMethodName); match {
+				if match, _ := regexp.MatchString("vdp.controller.v1alpha.ControllerPrivateService/.*", fullMethodName); match {
 					return false
 				}
 			}

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -93,7 +93,9 @@ func main() {
 		// can't handle the error due to https://github.com/uber-go/zap/issues/880
 		_ = logger.Sync()
 	}()
-	grpc_zap.ReplaceGrpcLoggerV2(logger)
+
+	// verbosity 3 will avoid [transport] from emitting
+	grpc_zap.ReplaceGrpcLoggerV2WithVerbosity(logger, 3)
 
 	// Create tls based credential.
 	var creds credentials.TransportCredentials
@@ -111,6 +113,10 @@ func main() {
 			// will not log gRPC calls if it was a call to liveness or readiness and no error was raised
 			if err == nil {
 				if match, _ := regexp.MatchString("vdp.model.v1alpha.ModelPublicService/.*ness$", fullMethodName); match {
+					return false
+				}
+				// stop logging successful private function calls
+				if match, _ := regexp.MatchString("model.model.v1alpha.ModelPrivateService/.*Admin$", fullMethodName); match {
 					return false
 				}
 			}
@@ -242,8 +248,6 @@ func main() {
 		logger.Info("[controller] control loop started")
 		var mainWG sync.WaitGroup
 		for {
-			logger.Info("[controller] --------------Start probing------------")
-
 			for etcdClient.ActiveConnection().GetState() != connectivity.Ready {
 				logger.Warn("[controller] etcd connection lost, waiting for state change...")
 				etcdClient.ActiveConnection().WaitForStateChange(ctx, connectivity.TransientFailure)

--- a/pkg/service/connector.go
+++ b/pkg/service/connector.go
@@ -99,6 +99,10 @@ func (s *service) ProbeConnectors(ctx context.Context, cancel context.CancelFunc
 			state = resp.State
 		}
 
+		if state != connectorPB.ConnectorResource_STATE_CONNECTED {
+			logger.Warn(fmt.Sprintf("[Controller] %s: %v", connector.Id, state))
+		}
+
 		if err := s.UpdateResourceState(ctx, &controllerPB.Resource{
 			ResourcePermalink: resourcePermalink,
 			State: &controllerPB.Resource_ConnectorState{
@@ -107,8 +111,6 @@ func (s *service) ProbeConnectors(ctx context.Context, cancel context.CancelFunc
 		}); err != nil {
 			logger.Error(err.Error())
 		}
-		logResp, _ := s.GetResourceState(ctx, resourcePermalink)
-		logger.Info(fmt.Sprintf("[Controller] Got %v", logResp))
 	}
 
 	return nil

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -142,6 +142,9 @@ func (s *service) ProbePipelines(ctx context.Context, cancel context.CancelFunc)
 				if resErr != nil {
 					logger.Error(fmt.Sprintf("UpdateResourceState failed for2 %s", release.Name))
 				}
+
+				logger.Warn(fmt.Sprintf("[Controller] %s: %v", release.Id, &releaseResource.State))
+
 				return
 			}
 
@@ -152,9 +155,6 @@ func (s *service) ProbePipelines(ctx context.Context, cancel context.CancelFunc)
 			if resErr != nil {
 				logger.Error(fmt.Sprintf("UpdateResourceState failed for3 %s", release.Name))
 			}
-
-			logResp, _ := s.GetResourceState(ctx, resourcePermalink)
-			logger.Info(fmt.Sprintf("[Controller] Got %v", logResp))
 		}(release)
 	}
 


### PR DESCRIPTION
Because

- currently backends in Instill Base Instill VDP and Instill Model will emit a huge amount of logs with level Info, which can overwhelm stdout

This commit

- refactor grpc logger `verbosity` and bypass successful private function calls
- only log resource state if not align with desire state